### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -1,9 +1,9 @@
-  RF24BLE KEYWORD1
-  begin KEYWORD2
-  setPhone KEYWORD2
-  setMAC KEYWORD2
-  setName KEYWORD2
-  setData KEYWORD2
-  sendADV KEYWORD2
-  getPacketLengthCurr KEYWORD2
+  RF24BLE	KEYWORD1
+  begin	KEYWORD2
+  setPhone	KEYWORD2
+  setMAC	KEYWORD2
+  setName	KEYWORD2
+  setData	KEYWORD2
+  sendADV	KEYWORD2
+  getPacketLengthCurr	KEYWORD2
  


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords